### PR TITLE
Football jersey additions

### DIFF
--- a/svgs/jersey/football3.svg
+++ b/svgs/jersey/football3.svg
@@ -4,7 +4,7 @@
 		<path id="collarSecondary" class="collarSecondary" d="M120 505C120 540 170 530 200 550C230 530 280 540 280 505L295 495C300 555 240 540 200 570C160 540 100 555 105 495L120 505Z" fill="$[secondary]" stroke="#000000" stroke-width="2"/>
 		<g id="Verticle Stripes">
 			<path id="vStripes1" class="vStripes1" d="M55 490L30 495L20 500L20 580L55 580L55 490ZM345 490L370 495L380 500L380 580L345 580L345 490Z" fill="$[secondary]" stroke="#000000" stroke-width="2"/>
-			<path id="vStripes2" class="vStripes2" d="M30 495L45 491.86L45 580L30 580L30 495ZM370 495L355 491.86L355 580L370 580L370 495Z" fill="$[accent]" stroke="#000000" stroke-width="2"/>
+			<path id="vStripes2" class="vStripes2" d="M30 495L45 491.86L45 580L30 580L30 495ZM370 495L355 491.86L355 580L370 580L370 495Z" fill="white" stroke="#000000" stroke-width="2"/>
 		</g>
 		<path id="footballStroke" class="footballStroke" d="M120 505C120 540 170 530 200 550C230 530 280 540 280 505C310 480 370 490 380 500C390 510 390.07 520.41 395 550C400 580 400 570 400 610L0 610C0 570 0 580 5 550C9.93 520.41 10 511.03 20 500C29.5 489.52 90 480 120 505Z" fill="none" stroke="#000000" stroke-width="6"/>
 		<path id="shoulderpads" class="shp3" d="M19.5 570C19.5 570 92 567.89 101 550 M381 570C381 570 310 567.89 301 550" fill="none" stroke="#000000" stroke-width="2" />

--- a/svgs/jersey/football5.svg
+++ b/svgs/jersey/football5.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 600" width="400" height="600">
+    <g id="football5">
+        <path id="footballWhite" d="M120,505C120,540 170,530 200,550C230,530 280,540 280,505C310,480 370,490 380,500C390,510 390.07,520.41 395,550C400,580 400,570 400,610L0,610C0,570 0,580.41 5,550.41C9.93,520.82 10,511.03 20,500C29.5,489.52 90,480 120,505Z" style="fill:white;fill-rule:nonzero;stroke:black;stroke-width:6px;"/>
+        <g transform="matrix(-1,0,0,1,400.837,0)">
+            <path d="M388.812,518.932C388.393,515.594 391.606,529.63 395,550C400,580 400,570 400,610L342.837,610L388.812,518.932Z" style="fill:$[primary];"/>
+        </g>
+        <path d="M388.812,518.932C388.393,515.594 391.606,529.63 395,550C400,580 400,570 400,610L342.837,610L388.812,518.932Z" style="fill:$[primary];"/>
+        <path d="M28.441,497.904L57.812,610.86L11.403,518.932C13.145,505.054 18.471,497.428 28.441,497.904Z" style="fill:$[secondary];stroke:black;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;"/>
+        <g transform="matrix(-1,0,0,1,400.215,0)">
+            <path d="M28.441,497.904L57.812,610.86L11.403,518.932C13.145,505.054 18.471,497.428 28.441,497.904Z" style="fill:$[secondary];stroke:black;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;"/>
+        </g>
+        <path id="collarPrimary" d="M120,505C120,540 170,530 200,550C230,530 280,540 280,505L295,495C300,555 240,540 200,570C160,540 100,555 105,495L120,505Z" style="fill:$[primary];fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+        <path id="footballStroke" d="M120,505C120,540 170,530 200,550C230,530 280,540 280,505C310,480 370,490 380,500C390,510 390.07,520.41 395,550C400,580 400,570 400,610L0,610C0,570 0,580 5,550C9.93,520.41 10,511.03 20,500C29.5,489.52 90,480 120,505Z" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:6px;"/>
+        <path id="shoulderpads" d="M19.5,570C19.5,570 92,567.89 101,550M381,570C381,570 310,567.89 301,550" style="fill:none;fill-rule:nonzero;stroke:black;stroke-width:2px;"/>
+    </g>
+</svg>


### PR DESCRIPTION
2 changes included in this potential PR.

1. Changing jersey **football3** to have white middle stripes on the shoulders rather than accent color. The accent color in the middle rarely looks good, and it looks a little cleaner with white. Example below for default teams Buffalo Wings and Baltimore Crabs. Happy for input here!
2. Adding jersey **football5**. This jersey effectively adds colored sleeves, as well as a colored divider between the chest and sleeve. The style I went with here was that the base jersey would be white, and the primary would be collar & sleeve, and secondary color is the divider. Tested this locally with editor.html, have not included it with any real teams yet.

### White stripe change
![image](https://user-images.githubusercontent.com/5054058/129490912-96d78393-bf9c-49b3-a9a1-5ad845cb126d.png)

### football5
![image](https://user-images.githubusercontent.com/5054058/129490987-3efda95c-707b-40c7-92c4-f0dde2ff5ebc.png)
![image](https://user-images.githubusercontent.com/5054058/129491111-1c4ce421-eec2-4e05-9eeb-5c73439bff93.png)
![image](https://user-images.githubusercontent.com/5054058/129491115-248792f5-330c-4820-ac3d-ad01d743cff1.png)

